### PR TITLE
Load only for the vim and help filetypes

### DIFF
--- a/plugin/helpful.vim
+++ b/plugin/helpful.vim
@@ -1,5 +1,4 @@
 augroup help_versions
   autocmd! FileType vim,help call helpful#setup()
+  autocmd! FileType vim,help command! -nargs=+ -complete=help HelpfulVersion call helpful#lookup('<args>')
 augroup END
-
-command! -nargs=+ -complete=help HelpfulVersion call helpful#lookup('<args>')


### PR DESCRIPTION
I don't know if there is ever any reason to load it for other filetypes? It seems to me that it's useful only for these filetypes?