### PR TITLE
Fix the command declaration

### DIFF
--- a/plugin/helpful.vim
+++ b/plugin/helpful.vim
@@ -2,4 +2,4 @@ augroup help_versions
   autocmd! FileType vim,help call helpful#setup()
 augroup END
 
-command! -nargs=+ -complete=help HelpfulVersion call helpful#lookup('<args>')
+command! -nargs=+ -complete=help HelpfulVersion call helpful#lookup(<q-args>)


### PR DESCRIPTION
Give an option name surrounded with `'` to a command argument like
`:HelpfulVersion 'shiftwidth'` didn't work.

This PR fixes it.