### PR TITLE
Add GitHub Action to automatically update tags

### DIFF
--- a/.github/workflows/update-tags.yml
+++ b/.github/workflows/update-tags.yml
@@ -1,0 +1,29 @@
+name: Update Tags
+
+on:
+  # Run at midnight every day
+  schedule:
+  - cron: '0 0 * * *'
+
+jobs:
+  update:
+    name: Update Tags
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v2
+    - name: update tags
+      run: make update
+    - name: get date
+      id: date
+      run: echo "::set-output name=date::$(date --rfc-3339=seconds)"
+    - name: check for update
+      id: diff
+      run: echo "::set-output name=diff::$(git diff --name-only data/)"
+    - name: push
+      uses: actions-x/commit@v2
+      with:
+        name: Tag Update Bot
+        files: data/tags doc/helpful-version.txt
+        message: Auto-updated tags ${{ steps.date.outputs.date }}
+      if: ${{ steps.diff.outputs.diff != '' }}


### PR DESCRIPTION
This will automatically run `make update` every day at midnight and will commit and push if `data/tags` changes so the tags are always kept up to date. The commit message and author and frequency and so on can all be modified if you'd prefer something else. You can see what the commits look like at my [fork](https://github.com/whonore/helpful.vim/commits/master).