### PR TITLE
Update actions

### DIFF
--- a/.github/workflows/update-tags.yml
+++ b/.github/workflows/update-tags.yml
@@ -3,7 +3,7 @@ name: Update Tags
 on:
   # Run at midnight every day
   schedule:
-  - cron: '0 0 * * *'
+  - cron: '@daily'
 
 jobs:
   update:

--- a/.github/workflows/update-tags.yml
+++ b/.github/workflows/update-tags.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: update tags
       run: make update
     - name: get date
@@ -21,7 +21,7 @@ jobs:
       id: diff
       run: echo "::set-output name=diff::$(git diff --name-only data/)"
     - name: push
-      uses: actions-x/commit@v2
+      uses: actions-x/commit@v5
       with:
         name: Tag Update Bot
         files: data/tags doc/helpful-version.txt


### PR DESCRIPTION
Something changed in `actions/checkout` that was causing `actions-x/commit` to fail. Updating to the most recent versions seems to fix it.
