### PR TITLE
Revert "Use @daily alias"

### DIFF
--- a/.github/workflows/update-tags.yml
+++ b/.github/workflows/update-tags.yml
@@ -3,7 +3,7 @@ name: Update Tags
 on:
   # Run at midnight every day
   schedule:
-  - cron: '@daily'
+  - cron: '0 0 * * *'
 
 jobs:
   update:


### PR DESCRIPTION
This reverts commit 3e520ed6ed7d74f650d77f54bf1b0674c82b6b11.

Sorry, I didn't check the docs carefully enough and apparently GitHub doesn't like cron aliases.