### PR TITLE
Fixed timestamp sorting being based on the string of the number.

### DIFF
--- a/support/difftags.py
+++ b/support/difftags.py
@@ -115,7 +115,7 @@ def repo_tags(path):
 
     tags = [('alpha', first, None)]
     stdout = command(cmd, print_stderr=False, cwd=path)
-    for line in sorted(stdout, key=lambda x: x.split()[0]):
+    for line in sorted(stdout, key=lambda x: int(x.split()[0])):
         parts = line.decode('utf8').split()
         timestamp, tz = parts[:2]
         tag_date = date.fromtimestamp(int(timestamp))


### PR DESCRIPTION
While trying to make the vim tag database additionally parse [vim-history](https://github.com/vim/vim-history/commits/master/) for vim tags, I discovered that the `repo_tags()` function doesn't convert the timestamp to an int before sorting it, which leads to incorrect results. This pull request fixes that bug.